### PR TITLE
Add styling to messages!

### DIFF
--- a/Discord.js
+++ b/Discord.js
@@ -4,11 +4,15 @@ const minotar = (user) => `https://minotar.net/avatar/${user}`;
 
 let channel;
 let guild;
+let discordSyntaxColor;
 exports.setGuild = (newGuild) => {
   guild = newGuild;
 };
 exports.setChannel = (newChannel) => {
   channel = newChannel;
+};
+exports.setDiscordMessageColor = (newColor) => {
+  discordSyntaxColor = newColor;
 };
 exports.login = (token) => client.login(token);
 exports.client = client;
@@ -17,7 +21,7 @@ exports.broadcast = ({ message }, player) => {
   const c = g.channels.cache.get(channel);
   const embed = new Discord.MessageEmbed()
     .setAuthor(player.username, minotar(player.username))
-    .setColor("BLUE")
+    .setColor(discordSyntaxColor)
     .setDescription(message);
   c.send(embed);
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,12 @@ exports.server = (serv) => {
   Discord.login(settings.token);
   Discord.setGuild(settings.guild);
   Discord.setChannel(settings.channel);
-  if(settings.serverMessage===null){
+  if(("discordMessageColor" in settings)) {
+    Discord.setDiscordMessageColor(settings.discordMessageColor);
+  } else {
+    Discord.setDiscordMessageColor("BLUE");
+  };
+  if(!("serverMessage" in settings)){
     syntax = "§b[Discord] §7${message.author.tag}§f: §7${message.content}"
   } else if (settings.serverMessage.contains("{name}")==true || settings.serverMessage.contains("{message}")==true){
     syntax = settings.serverMessage.replace("&", "§");

--- a/index.js
+++ b/index.js
@@ -1,13 +1,25 @@
 const Discord = require("./Discord");
 exports.server = (serv) => {
+  let syntax;
   const settings = serv.plugins.squidcord.settings;
   require("./thrower").checkConfig(settings, serv);
   Discord.login(settings.token);
   Discord.setGuild(settings.guild);
   Discord.setChannel(settings.channel);
+  if(settings.serverMessage===null){
+    syntax = "§b[Discord] §7${message.author.tag}§f: §7${message.content}"
+  } else if (settings.serverMessage.contains("{name}")==true || settings.serverMessage.contains("{message}")==true){
+    syntax = settings.serverMessage.replace("&", "§");
+    syntax = syntax.replace("{name}", "${message.author.tag}");
+    syntax = syntax.replace("{message}", "${message.content}");
+  } else if (settings.serverMessage.contains("{name}")==false || settings.serverMessage.contains("{message}")==false) {
+    syntax = "§b[Discord] §7${message.author.tag}§f: §7${message.content}"
+    console.log("[SquidCord] The serverMessage setting didn't have {name} or {message}!");
+    console.log("[SquidCord] Include {name} and {message} in serverMessage or leave it null to default.");
+  }
   Discord.setChatHandler((message) => {
     serv.broadcast(
-      `§b[Discord] §7${message.author.tag}§f: §7${message.content}`
+      `${syntax}`
     );
   });
 };


### PR DESCRIPTION
I added 2 new properties: "serverMessage" and "discordMessageColor".
"serverMessage" property can have color codes (Replaces '&' with that symbol) and it also replaces {name} with discord username and {message} with message.content
"discordMessageColor" is just the embed color.
I also made it that the properties are optional, so it doesnt crash when you dont type them. (When its not presented, its made to be the default settings.)